### PR TITLE
cd: update NPM_TOKEN in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
       - name: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.ASSOCIATION_NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.WC_NPM_RELEASE_TOKEN }}
         run: |
           cd dist
           yarn --frozen-lockfile


### PR DESCRIPTION
Updates the NPM token secret reference in the GitHub Actions release workflow from ASSOCIATION_NPM_TOKEN to WC_NPM_RELEASE_TOKEN. This change ensures the signing-manager-types package uses its dedicated NPM token for releases rather than a generic association token, providing better security isolation and token management for this specific project.